### PR TITLE
Mongo caller fixes

### DIFF
--- a/lib/callstack.js
+++ b/lib/callstack.js
@@ -6,12 +6,12 @@ module.exports = {
    * Get information about the function which called the current function.
    * (i.e. get the caller of the caller of this function)
    *
-   * This will ignore unamed lambda functions and will attempt to ignore library functions such as
+   * This will ignore unnamed lambda functions and will attempt to ignore library functions such as
    * `_.map` or `Array.map` which simply call a function passed to them.
    *
    * On failure, it will return an empty object.
    *
-   * @note Unfuntatnely the exact answer is partially dependent on what version of node is in use.
+   * @note Unfortunately the exact answer is partially dependent on what version of node is in use.
    *  Older node versions (<v12) will name lambdas in the call stack, meaning the "caller" of
    *  ```
       function fn2() {
@@ -28,9 +28,12 @@ module.exports = {
    */
   getCaller() {
     const stack = getStack().slice(1)
+
     let foundThis = false // (caller of this function)
     for (const i of stack) {
-      const name = i.getMethodName() || i.getFunctionName()
+      const method = i.getMethodName()
+      const fn = i.getFunctionName()
+      const name = method || fn
       const file = i.getFileName()
       const line = i.getLineNumber()
       const column = i.getColumnNumber()
@@ -38,8 +41,8 @@ module.exports = {
       // ignore unattached lambdas
       if (!name) continue
 
-      // make suere it is not a lib function such as Array.map or _.map
-      if (!file) continue // common failiure with `<anonymous>` for stdlib function
+      // make sure it is not a lib function such as Array.map or _.map
+      if (!file) continue // common failure with `<anonymous>` for stdlib function
       const callerPath = parse(file)
 
       const pathArray = callerPath.dir.split(sep)
@@ -47,7 +50,7 @@ module.exports = {
       const isQuadroFunction = pathArray.find(j => j === 'quadro')
       if (isModuleFunction && !isQuadroFunction) {
         // handle _.map and other module provided functions
-        // but do not ignore funtions such as the mongo function wrappers provided by this lib
+        // but do not ignore functions such as the mongo function wrappers provided by this lib
         continue
       }
 
@@ -58,7 +61,7 @@ module.exports = {
       }
 
       // finally found the correct function
-      return {name, file, fileName: callerPath.name, line: line, column: column}
+      return { name, fn, method, file, fileName: callerPath.name, line, column }
     }
 
     // failed to find function

--- a/services/mongo.js
+++ b/services/mongo.js
@@ -55,6 +55,10 @@ function metricsWrapFunction(fn, fnName, metrics) {
     // SETUP
     // labels for all metrics
     const caller = getCaller()
+    if (caller.fileName === 'mongo' && caller.fn === 'metricsFunctionWrapper') {
+      // escape hatch for when mongo calls itself (we don't want to double record metrics)
+      return fn(...arguments)
+    }
     const labels = {
       function: caller.name,
       filename: caller.fileName,


### PR DESCRIPTION
OPT-378

Found the issue which was causing us to see our wrapper as a metrics source. Basically what was happening is some functions such as findOne in mongo collection will call itself (in this example it calls `this.find`) which causes the wrapper to record twice for the same call.

This means it should be safe to recognize cases where the caller was the wrapper and then not record again as the outermost wrapper has the most useful information.

I have only seen this go one layer deep, so I am not terribly concerned about the performance of the extra callstack fetch, though I did try some other options to prevent that extra load which all failed due to one of the following:
1) the function has been bound so you cannot set properties on the instance and still access them
2) cannot store it globally because it is asynchronous
3) not able to add extra parameters easily since you don't know if you are calling the wrapper or an actual mongo function that has been bound.