### PR TITLE
Handle non-object messages gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadro",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "framework",
     "quadro",

--- a/services/pubsub/hub_message_processor.js
+++ b/services/pubsub/hub_message_processor.js
@@ -85,6 +85,10 @@ module.exports = class HubMessageProcessor {
     let parsedMessage
     try {
       parsedMessage = JSON.parse(message.content.toString())
+
+      if (typeof parsedMessage !== 'object' || Array.isArray(parsedMessage)) {
+        throw new Error('Message was not an object');
+      }
     } catch (err) {
       this.log.error({err}, `Error while parsing message: ${parsedMessage}`)
       return

--- a/services/pubsub/hub_message_processor.js
+++ b/services/pubsub/hub_message_processor.js
@@ -87,7 +87,7 @@ module.exports = class HubMessageProcessor {
       parsedMessage = JSON.parse(message.content.toString())
 
       if (typeof parsedMessage !== 'object' || Array.isArray(parsedMessage)) {
-        throw new Error('Message was not an object');
+        throw new Error('Message was not an object')
       }
     } catch (err) {
       this.log.error({err}, `Error while parsing message: ${parsedMessage}`)


### PR DESCRIPTION
It's possible for an incoming message to be parsed successfully without actually being an object, which causes the handler to fail silently and redeliver the message infinitely. This fix handles the edge case.